### PR TITLE
ci: add Django 5.2/6.x and Python 3.12-3.14 as allow-failure matrix entries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,26 @@ jobs:
   build:
     name: Build and test ${{ matrix.python-version }} - ${{ matrix.django-version }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
-      matrix: 
+      fail-fast: false
+      matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         django-version: ['3.2', '4.1', '4.2']
+        experimental: [false]
+        include:
+          - python-version: '3.12'
+            django-version: '5.2'
+            experimental: true
+          - python-version: '3.13'
+            django-version: '6.0'
+            experimental: true
+          - python-version: '3.13'
+            django-version: '6.1'
+            experimental: true
+          - python-version: '3.14'
+            django-version: '6.1'
+            experimental: true
     steps:
       - name: Checkout project
         uses: actions/checkout@v3


### PR DESCRIPTION
Part of the compatibility maintenance proposed in #94.

## Summary
Widens the CI matrix to also cover Django 5.2 LTS/6.0/6.1 and Python 3.12/3.13/3.14, purely to
surface real breakage — no change to the currently supported floor (Python >=3.8, Django >=3.2).

## Mechanics
- New cells run with job-level `continue-on-error: ${{ matrix.experimental }}`, so a real failure
  there does not fail the workflow run, does not block PR merge, and does not block the `sonar`
  job (which depends on `needs: [build]` — a job with `continue-on-error: true` reports
  `conclusion: success` regardless of step failures).
- `fail-fast: false` added so a failing experimental cell can't cancel the existing required
  cells.
- New versions are added via `matrix.include` with values outside the base cross-product, so
  they're additional jobs, not replacements.

Promoting these to required (dropping `continue-on-error`) once they're green, and fixing any
real breakage they surface, is intentionally left as follow-up — not part of this PR.