### PR TITLE
ci: add Dependabot config for pip and github-actions ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` scheduling weekly update PRs for the `pip` ecosystem (covers Poetry/`poetry.lock`) and for GitHub Actions used in workflows.

## Test plan
- N/A — CI config only, no code changes.